### PR TITLE
Add localization to DisplayUnitSystem and pull localized strings from Culture object

### DIFF
--- a/globalize/globalize.cultures.ts
+++ b/globalize/globalize.cultures.ts
@@ -6929,6 +6929,18 @@ export default function injectCultures(Globalize) {
                     Y: "MMMM yyyy"
                 }
             }
+        },
+        localizedStrings: {
+            DisplayUnitSystem_EAuto_Title: "Auto",
+            DisplayUnitSystem_E0_Title: "None",
+            DisplayUnitSystem_E3_LabelFormat: "{0}Tsd.",
+            DisplayUnitSystem_E3_Title: "Tausend",
+            DisplayUnitSystem_E6_LabelFormat: "{0}Mio.",
+            DisplayUnitSystem_E6_Title: "Millionen",
+            DisplayUnitSystem_E9_LabelFormat: "{0}Mrd.",
+            DisplayUnitSystem_E9_Title: "Milliarden",
+            DisplayUnitSystem_E12_LabelFormat: "{0}Trill.",
+            DisplayUnitSystem_E12_Title: "Trillionen", 
         }
     });
 

--- a/src/formattingService/iFormattingService.ts
+++ b/src/formattingService/iFormattingService.ts
@@ -24,6 +24,8 @@
 *  THE SOFTWARE.
 */
 
+import { Culture } from "./formattingService";
+
 // Enumeration of DateTimeUnits
 export enum DateTimeUnit {
     Year,
@@ -42,7 +44,7 @@ export interface IFormattingService {
      * @param value - value to be formatted and converted to string.
      * @param format - format to be applied. If undefined or empty then generic format is used.
      */
-    formatValue(value: any, format?: string, cultureSelector?: string): string;
+    formatValue(value: any, format?: string, cultureSelector?: string|Culture): string;
 
     /**
      * Replaces the indexed format tokens (for example {0:c2}) in the format string with the localized formatted arguments.
@@ -50,14 +52,20 @@ export interface IFormattingService {
      * @param args - array of values which should replace the tokens in the format string.
      * @param culture - localization culture. If undefined then the current culture is used.
      */
-    format(formatWithIndexedTokens: string, args: any[], culture?: string): string;
+    format(formatWithIndexedTokens: string, args: any[], culture?: string|Culture): string;
 
     // Gets a value indicating whether the specified format a standard numeric format specifier.
     isStandardNumberFormat(format: string): boolean;
 
     // Performs a custom format with a value override.  Typically used for custom formats showing scaled values.
-    formatNumberWithCustomOverride(value: number, format: string, nonScientificOverrideFormat: string, culture?: string): string;
+    formatNumberWithCustomOverride(value: number, format: string, nonScientificOverrideFormat: string, culture?: string|Culture): string;
 
     // Gets the format string to use for dates in particular units.
     dateFormatString(unit: DateTimeUnit): string;
+    
+    /**
+     * Gets the culture object
+     * @param cultureOrCultureSelector - either a culture selector or if the culture was already retrieved earlier just return the same object back to avoid multiple lookups
+    */ 
+    getCulture(cultureOrCultureSelector?: string|Culture): Culture;
 }

--- a/test/displayUnitSystem/displayUnitSystemTest.ts
+++ b/test/displayUnitSystem/displayUnitSystemTest.ts
@@ -123,7 +123,7 @@ describe("DisplayUnitSystem", () => {
     });
 
     function createDisplayUnitSystem(units?: DisplayUnit[]): DisplayUnitSystem {
-        return new DisplayUnitSystem(units);
+        return new DisplayUnitSystem(null, units);
     }
 });
 
@@ -155,7 +155,7 @@ describe("DataLabelsDisplayUnitSystem", () => {
     function createDataLabelsDisplayUnitSystem(systemNames: DisplayUnitSystemNames[]): DataLabelsDisplayUnitSystem {
         return new DataLabelsDisplayUnitSystem((exponent: number) => {
             return systemNames[exponent] || systemNames[0];
-        });
+        }, null);
     }
 
     function createDisplayUnitSystemNames(): DisplayUnitSystemNames[] {


### PR DESCRIPTION
This pull request aims to support localization of the DisplayUnitSystem discussed in #36 .   
I changed the signature of the **describe** function in **valueFormatter.ts@localizationOptions** from
```
(exponent: number) => DisplayUnitSystemNames
```
to 
```
(exponent: number, culture: Culture) => DisplayUnitSystemNames
```
to support giving out different objects based on the configured culture of the formatter.  
Further on I extended the culture type to contain an optional **localizedStrings** property. In the default describe function I try to pull the format and title value from the localizedStrings property of the culture object, otherwise I default back to **valueFormatter.ts@localizationOptions**.  
Also every instance of DisplayUnitSystem now has a assigned culture object that it retrieves in it's constructor. Therefore it does no longer make sense to cache units in the static property since different instances of DisplayUnitSystem can have different cultures and therefore need different unit objects. A cache could be implemented nontheless but is not necessary in my opinion.  
I aimed for minimal modifications under the constraint that the localization information should be supplied through the culture object defined in **globalize/globalize.cultures.ts**. I also added localizationStrings for the german language culture object. Unfortunately I do not have the resources to add the appropriate localizedStrings object for other languages.